### PR TITLE
Extract library functions for better reuse later

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ Advent of Code for 2021
 
 Per day, remember to:
 ```
-cargo new day01
-cp hellowrold/Makefile day01/
+export day=day02
+cargo new $day
+cp helloworld/Makefile $day/
+touch $day/README.md
+cp day01/src/filelib.rs $day/src/filelib.rs
 ```
 
 By convention for this repo, so I can ignore it, all programs will be called `<foldername>.day` eg `day01.day`.

--- a/day01/src/filelib.rs
+++ b/day01/src/filelib.rs
@@ -1,0 +1,55 @@
+use std::fs;
+
+/// Load the "input" file
+pub fn load(filename: &str) -> String {
+    let contents = fs::read_to_string(filename).expect("Something went wrong reading");
+    return contents;
+}
+
+/// remove blank lines
+fn remove_blanks(text_input: &str) -> Vec<String> {
+    return text_input
+        .lines()
+        .filter(|&s| !s.is_empty() && !s.trim().is_empty())
+        .map(str::to_string)
+        .collect();
+}
+
+/// Load without blank lines
+pub fn load_no_blanks(filename: &str) -> Vec<String> {
+    return remove_blanks(&load(filename));
+}
+
+fn strings_to_i32(strings: Vec<&str>) -> Vec<i32> {
+    let result: Vec<i32> = strings.iter().map(|x| x.parse::<i32>().unwrap()).collect();
+    return result;
+}
+
+/// Load and convert to 32-bit integers
+pub fn load_as_ints(filename: &str) -> Vec<i32> {
+    let strings = load_no_blanks(filename);
+    return strings_to_i32(strings.iter().map(AsRef::as_ref).collect());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_blanks() {
+        let input = "\n199\n200\n208\n210\n\n200\n207\n240\n269\n260\n263\n";
+        let expected = vec![
+            "199", "200", "208", "210", "200", "207", "240", "269", "260", "263",
+        ];
+        assert_eq!(remove_blanks(input), expected);
+    }
+
+    #[test]
+    fn test_strings_to_i32() {
+        let input = vec![
+            "199", "200", "208", "210", "200", "207", "240", "269", "260", "263",
+        ];
+        let expected = vec![199, 200, 208, 210, 200, 207, 240, 269, 260, 263];
+        assert_eq!(strings_to_i32(input), expected);
+    }
+}

--- a/day01/src/lib.rs
+++ b/day01/src/lib.rs
@@ -1,8 +1,6 @@
 mod filelib;
 
-pub fn load_as_ints(filename: &str) -> Vec<i32> {
-    return crate::filelib::load_as_ints(filename);
-}
+pub use crate::filelib::load_as_ints;
 
 /// Get the number of times depths increases
 /// ```

--- a/day01/src/lib.rs
+++ b/day01/src/lib.rs
@@ -1,28 +1,7 @@
-use std::fs;
+mod filelib;
 
-/// Load the "input" file
-pub fn load() -> String {
-    let contents = fs::read_to_string("input").expect("Something went wrong reading");
-    return contents;
-}
-
-/// parse A string, including empty lines, to a list of integers
-///
-/// This filters out empty lines, and returns a vector of i32s.
-///
-/// ```
-/// assert_eq!(day01::parse_string("1\n2"), vec![1, 2]);
-/// ```
-pub fn parse_string(text_input: &str) -> Vec<i32> {
-    let no_empty_lines: Vec<&str> = text_input
-        .lines()
-        .filter(|&s| !s.is_empty() && !s.trim().is_empty())
-        .collect::<Vec<_>>();
-    let result: Vec<i32> = no_empty_lines
-        .iter()
-        .map(|x| x.parse::<i32>().unwrap())
-        .collect();
-    return result;
+pub fn load_as_ints(filename: &str) -> Vec<i32> {
+    return crate::filelib::load_as_ints(filename);
 }
 
 /// Get the number of times depths increases
@@ -65,14 +44,6 @@ pub fn puzzle_b(depths: &Vec<i32>) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_string() {
-        let input = "199\n200\n208\n210\n200\n207\n240\n269\n260\n263\n";
-        let expected = vec![199, 200, 208, 210, 200, 207, 240, 269, 260, 263];
-        let result = parse_string(input);
-        assert_eq!(result, expected);
-    }
 
     #[test]
     fn test_sliding_window() {

--- a/day01/src/main.rs
+++ b/day01/src/main.rs
@@ -1,11 +1,10 @@
-use day01::load;
-use day01::parse_string;
+use day01::load_as_ints;
 use day01::puzzle_a;
 use day01::puzzle_b;
 
 fn main() {
-    let contents = load();
-    let depths = parse_string(&contents);
+    let filename = "input";
+    let depths = load_as_ints(filename);
 
     let value = puzzle_a(&depths);
     println!("Answer to 1st question: {}", value);


### PR DESCRIPTION
We are likely going to have load files, and load integers again. Keep a file we can copy and paste without worrying about it.